### PR TITLE
dashboard role assignment

### DIFF
--- a/subjects/subjects.go
+++ b/subjects/subjects.go
@@ -1,6 +1,0 @@
-package subjects
-
-const (
-	RoleDeletedSubject = "be.core.events.role.deleted"
-	RoleCheckSubject   = "be.core.request.role.check"
-)

--- a/subjects/subjects.go
+++ b/subjects/subjects.go
@@ -1,0 +1,6 @@
+package subjects
+
+const (
+	RoleDeletedSubject = "be.core.events.role.deleted"
+	RoleCheckSubject   = "be.core.request.role.check"
+)

--- a/utils/notification/notification.go
+++ b/utils/notification/notification.go
@@ -8,6 +8,11 @@ import (
 const (
 	EventKeyword = "$event"
 	SysKeyword   = "$sys"
+
+	BeKeyword         = "be"
+	CoreKeyword       = "core"
+	DeleteRoleKeyword = "delete.role"
+	CheckRoleKeyword  = "check.role"
 )
 
 func BuildSubject(profile, vendor string, extName ...string) string {
@@ -15,4 +20,8 @@ func BuildSubject(profile, vendor string, extName ...string) string {
 		return strings.ToLower(fmt.Sprintf("local.%s.%s.%s.%s", EventKeyword, profile, vendor, SysKeyword))
 	}
 	return strings.ToLower(fmt.Sprintf("local.%s.%s.%s.%s", EventKeyword, profile, vendor, extName[0]))
+}
+
+func BuildLocalEventSysSubject(profile, vendor, subject string) string {
+	return fmt.Sprintf("local.%s.%s.%s.%s.%s", EventKeyword, profile, vendor, SysKeyword, subject)
 }

--- a/utils/notification/notification.go
+++ b/utils/notification/notification.go
@@ -6,13 +6,14 @@ import (
 )
 
 const (
-	EventKeyword = "$event"
-	SysKeyword   = "$sys"
+	EventKeyword        = "$event"
+	SysKeyword          = "$sys"
+	NotificationKeyword = "$notification"
 
-	BeKeyword         = "be"
-	CoreKeyword       = "core"
-	DeleteRoleKeyword = "delete.role"
-	CheckRoleKeyword  = "check.role"
+	BeProfile    = "be"
+	VendorPjnube = "pjnube"
+
+	DeleteRoleSubject = "delete.role"
 )
 
 func BuildSubject(profile, vendor string, extName ...string) string {
@@ -22,6 +23,6 @@ func BuildSubject(profile, vendor string, extName ...string) string {
 	return strings.ToLower(fmt.Sprintf("local.%s.%s.%s.%s", EventKeyword, profile, vendor, extName[0]))
 }
 
-func BuildLocalEventSysSubject(profile, vendor, subject string) string {
-	return fmt.Sprintf("local.%s.%s.%s.%s.%s", EventKeyword, profile, vendor, SysKeyword, subject)
+func BuildNotificationSysSubject(profile, vendor, subject string) string {
+	return fmt.Sprintf("local.%s.%s.%s.%s.%s", NotificationKeyword, profile, vendor, SysKeyword, subject)
 }


### PR DESCRIPTION
Summary:
1. because need to establish a connection between dashboardUuid and roleName in dashboard DB. One thing is when roleName is deleted in ros-server, need to send NATS Pub notification, and dashboard need to Sub this NATS notification. Another thing is when dashboard started, need to send NATS Request to check roseNames exist, and ros-server need to Response this NATS.

delete role subject: local.$notification.be.pjnube.$sys.delete.role
check role subject(just call a normal existed API call): local.be.pjnube.core.get.api.roles

Ticket:
https://pjoshua.atlassian.net/browse/PJN-1195

Ref PR:
https://github.com/PJNube/ros-server/pull/185
https://github.com/PJNube/extension-dashboard/pull/28